### PR TITLE
Enable FASTA-formatted sequence output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+._*
+*.o
+*~
+*.swp
+source/seq-gen

--- a/source/evolve.c
+++ b/source/evolve.c
@@ -76,6 +76,7 @@ void MutateSequence(char *seq, int inFromSite, int inNumSites, double len);
 void SetSiteRates(int inFromSite, int inNumSites, double inScale);
 void EvolveNode(TNode *anc, TNode *des, int inFromSite, int inNumSites, double scale);
 
+void WriteFastaFormat(FILE *fv, TTree **treeSet, int *partitionLengths);
 void WritePhylipFormat(FILE *fv, TTree **treeSet, int *partitionLengths);
 void WriteNexusFormat(FILE *fv, int treeNo, int datasetNo, TTree **treeSet, int *partitionLengths);
 
@@ -424,6 +425,9 @@ void WriteSequences(FILE *fv, int treeNo, int datasetNo, TTree **treeSet, int *p
 		case NEXUSFormat:
 			WriteNexusFormat(fv, treeNo, datasetNo, treeSet, partitionLengths);
 		break;
+		case FASTAFormat:
+			WriteFastaFormat(fv, treeSet, partitionLengths);
+		break;
 	}
 }
 
@@ -458,6 +462,32 @@ void WritePhylipFormat(FILE *fv, TTree **treeSet, int *partitionLengths)
 			}
 		}
 		fputc('\n', fv);
+	}
+}
+
+void WriteFastaFormat(FILE *fv, TTree **treeSet, int *partitionLengths)
+{
+	size_t i, j, k;
+
+	for (i=0; i<numTaxa; i++) {
+		size_t printedSites = 0;
+
+		fprintf(fv, ">%s\n", treeSet[0]->names[i]);
+
+		for (j = 0; j < numPartitions; j++) {
+			char *P;
+			P=treeSet[j]->tips[i]->sequence;
+			for (k=0; k<partitionLengths[j]; k++) {
+				fputc(stateCharacters[(int)*P], fv);
+				P++;
+				if (++printedSites % 72 == 0) {
+					fputc('\n', fv);
+				}
+			}
+		}
+		if (printedSites % 72 != 0) {
+			fputc('\n', fv);
+		}
 	}
 }
 

--- a/source/evolve.h
+++ b/source/evolve.h
@@ -63,7 +63,8 @@ enum {
 enum {
 	PHYLIPFormat,
 	RelaxedFormat,
-	NEXUSFormat
+	NEXUSFormat,
+	FASTAFormat
 };
 
 /* prototypes */

--- a/source/seq-gen.c
+++ b/source/seq-gen.c
@@ -128,6 +128,7 @@ static void PrintUsage()
 	fprintf(stderr, "    p PHYLIP format\n");
 	fprintf(stderr, "    r relaxed PHYLIP format\n");
 	fprintf(stderr, "    n NEXUS format\n");
+	fprintf(stderr, "    f FASTA format\n");
 	fprintf(stderr, "  -w: Write additional information [default = none]\n");
 	fprintf(stderr, "    a Write ancestral sequences for each node\n");
 	fprintf(stderr, "    r Write rate for each site\n");
@@ -447,6 +448,7 @@ void ReadParams(int argc, char **argv)
 						case 'P': fileFormat=PHYLIPFormat; break;
 						case 'R': fileFormat=RelaxedFormat; break;
 						case 'N': fileFormat=NEXUSFormat; break;
+						case 'F': fileFormat=FASTAFormat; break;
 						default:					
 							fprintf(stderr, "Unknown output format: %s\n\n", argv[i]);
 							PrintUsage();


### PR DESCRIPTION
Hi Andrew,

This PR enables the output of sequences in FASTA format.

I've also added a .gitignore file, informing git that we don't want to track compiled binaries or editor temp files.

Cheers,
Kevin

P.S., on behalf of at least Debian maintainers, thanks for `git tag`-ing releases. It makes automatically tracking new releases way easier. I'll fix the Debian package to watch the github tags page.