### PR TITLE
Added +1 to the checkCapacity function call

### DIFF
--- a/source/treefile.c
+++ b/source/treefile.c
@@ -313,7 +313,7 @@ TNode *ReadTip(FILE *fv, char ch, TTree *tree, int numNames, char **names)
 	}
 	*P='\0';
 
-	CheckCapacity(tree, tree->numTips);
+	CheckCapacity(tree, tree->numTips+1);
 	
 	if (numNames == 0) {
 		node->tipNo=tree->numTips;


### PR DESCRIPTION
Hi, 

Wanting to generate sequences from a newick tree having 1449 taxa, I had a seg fault.
It appeared that while reading a new tip (readTip function) the checkcapacity function was called before incrementing the tree numtips. Then at the moment of the capacity increase, the current taxon was "forgotten", thus having a null name and a null sequence and provoking the segfault at writeSequences.

You can reproduce the error with the attached tree.txt file:
`./seq-gen  -of -a0.441 -g4 -mWAG -l527 -z $RANDOM tree.txt > seq.fasta`

[tree.txt](https://github.com/rambaut/Seq-Gen/files/272630/tree.txt)

I propose to add "+1" to checkCapacity called in the readTip function. I don't know if the proposed modification may break other parts of your code,

Best,

Frederic
