### PR TITLE
Hacky fix to avoid heap corruption errors.

### DIFF
--- a/source/treefile.c
+++ b/source/treefile.c
@@ -146,7 +146,8 @@ void CheckCapacity(TTree *tree, int required)
 	TNode **newTips;
 	
 	while (newCapacity < required) {
-		newCapacity += 1000;
+		// Hacky fix to avoid memory corruption
+		newCapacity = required * 2;
 	}
 	
 	newNames = (char**)CAllocMem(sizeof(char*)*newCapacity, "newNames", "CheckCapacity", 0);


### PR DESCRIPTION
Heap was being corrupted with large amounts of simulated output (1000+ chromosomes with lengths of 1MB+).

This should help avoid that. However, it'd be best if the number of tips for all trees was calculated ahead of time, and only one `malloc()` call was made per tree.